### PR TITLE
Add guideline around postfix conditionals

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ course of your current work. Do not change code *only* to fix style.
 
 - Align `private`, `protected`, etc with other definitions (do not out-dent)
 - Avoid explicit `return`s
+- Avoid postfix conditionals
 - Avoid ternary operators
 - Don't use `self` unless required (`self.class` or attribute assignment)
 - Don't use redundant braces when passing hash arguments


### PR DESCRIPTION
This is an Avoid, not a Don't. Given a short enough statement, a postfix
conditional may not always be a "surprise" conditional, which is what should be
avoided.

---

There was a suggestion to make the above distinction more prevalent in the
guideline. I'm open to ideas, but can't think of suitable verbiage myself (I
don't want to make hard rules about statement length for example).

Personally, I like to err on the simple side of "if you can convince your pair"
when it comes to any Prefer/Avoid rules, rather than trying to specify
everything explicitly up front.
