### PR TITLE
Sort all lists lexically in the source

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ course of your current work. Do not change code *only* to fix style.
   foo.fetch(:bar)
   ```
 
-- Sort all lists (arrays, hashes, `require`s, etc)
+- Sort all lists at the time of declaration (array items, hash keys, `require`
+  statements, etc.)
 - Use `%r{ }` for regular expressions containing more than one `/`
 - Use `%w[ ]` for word-arrays
 - Use `%{ }` for strings containing more than one double quote


### PR DESCRIPTION
It was mentioned that this is ambiguous. We don't intend that you're supposed
to call `Enumerable#sort` on any Array object in your code. This is about
visuals: we should sort any lists in the code so that it's easy to see what's
present and what's not, avoid adding duplicate entries, and not have to make
any decisions about where to put something new.

Any change in language to make that more obvious is welcome.
