### PR TITLE
Add namespace guideline

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ course of your current work. Do not change code *only* to fix style.
 - Include a `.ruby_version`
 - Include a `bin/setup` script
 - Mirror `lib` in `spec`: `lib/foo/bar.rb => spec/foo/bar_spec.rb`
+- Use the `CC` namespace when it makes sense
 
 ## Specs
 


### PR DESCRIPTION
We need better language for "when it makes sense". The goal here is to avoid
the proliferation of namespaces currently in worker. Across all our apps, any
domain-specific objects should live under a single `CC` namespace. Generic
code, or code that could have its own identity outside of CC (e.g. ggrpc), can
use whatever namespace is appropriate.
