### PR TITLE
Style for defining exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,12 @@ course of your current work. Do not change code *only* to fix style.
 - Use parentheses when defining methods that take arguments
 - Don't use `unless` with an `else` branch. Switch the conditionals.
 - Do, or do not. There is no `try`.
-- Use `TerribleMorningException = Class.new(StandardError)` style of defining error classes when no added functionality needed
+- Define error classes with `Class.new` where no subclass behavior required:
 
+  ```rb
+  TerribleMorningException = Class.new(StandardError)
+  ```
+  
 ## Project structure
 
 - Include a `.ruby_version`


### PR DESCRIPTION
While not a common style, I like it for the reasons mentioned in this article:

http://blog.rubybestpractices.com/posts/gregory/anonymous_class_hacks.html

Relevant excerpt below:

> Although there are valid reasons for subclassing a StandardError, typically the only reason I am doing it is to get a named exception to rescue. I don’t plan to ever add any functionality to its subclass beyond a named constant. However, if we notice that Class.new can be used to create subclasses, you can write something that more clearly reflects this intention.

Note that the alternative is typically written as:

```
class RainExpectedException < StandardError; end
```

/cc @codeclimate/developers 
