### PR TITLE
Add a rubocop.yml, to be used by all projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ course of your current work. Do not change code *only* to fix style.
 - **Avoid**/**prefer**: if not following these, the burden is on you to convince
   your reviewer why
 
+## Rubocop
+
+Every project should start with the `rubocop.yml` present here. It should
+enforce the styles defined here.
+
+If a change or addition comes up in the course of that project that is not
+project-specific, it should be made in both places. Periodically, projects must
+"sync" their `.rubocop.yml` with the one present here.
+
 ## General
 
 - Align `private`, `protected`, etc with other definitions (do not out-dent)

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,0 +1,98 @@
+################################################################################
+# Metrics
+################################################################################
+
+Metrics/LineLength:
+  Enabled: false
+
+Metrics/AbcSize:
+  Enabled: false
+
+################################################################################
+# Style
+################################################################################
+
+# Executables are conventionally named bin/foo-bar
+Style/FileName:
+  Exclude:
+  - bin/**/*
+
+# We don't (currently) document our code
+Style/Documentation:
+  Enabled: false
+
+# Always use double-quotes to keep things simple
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+# Use a trailing comma to keep diffs clean when elements are inserted or removed
+Style/TrailingComma:
+  EnforcedStyleForMultiline: comma
+
+# We avoid GuardClause because it can result in "suprise return"
+Style/GuardClause:
+  Enabled: false
+
+# We avoid IfUnlessModifier because it can result in "suprise if"
+Style/IfUnlessModifier:
+  Enabled: false
+
+# We don't care about the fail/raise distinction
+Style/SignalException:
+  EnforcedStyle: only_raise
+
+Style/DotPosition:
+  EnforcedStyle: trailing
+
+# Common globals we allow
+Style/GlobalVars:
+  AllowedVariables:
+  - "$statsd"
+  - "$mongo"
+  - "$rollout"
+
+# We have common cases where has_ and have_ make sense
+Style/PredicateName:
+  Enabled: true
+  NamePrefixBlacklist:
+  - is_
+
+# We use %w[ ], not %w( ) because the former looks like an array
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    "%w": []
+    "%W": []
+
+################################################################################
+# Rails - disable things because we're primarily non-rails
+################################################################################
+
+Rails/Delegate:
+  Enabled: false
+
+Rails/TimeZone:
+  Enabled: false
+
+################################################################################
+# Specs - be more lenient on length checks and block styles
+################################################################################
+
+Metrics/ModuleLength:
+  Exclude:
+  - spec/**/*
+
+Metrics/MethodLength:
+  Exclude:
+  - spec/**/*
+
+Style/ClassAndModuleChildren:
+  Exclude:
+  - spec/**/*
+
+Style/BlockDelimiters:
+  Exclude:
+  - spec/**/*
+
+Style/Blocks:
+  Exclude:
+  - spec/**/*


### PR DESCRIPTION
/cc @codeclimate/review @codeclimate/developers

I think we'd get more mileage out of our rubocop checks if:
- All projects used a consistent configuration
- That configuration enforced more things than it does today

I've taken the config from all our apps and consolidated it into one here,
commented it, and updated some of the cops to actually enforce our style, not
just disable its enforcement of not-our-style (e.g. double-quotes).

My plan would be to discuss and commit this, then copy it into all the
projects. I'll either need a mercy-merge if the change introduces issues, have
to make some one-time style-only changes to get past them, or both. We'll see.
