### PR TITLE
Allow "trivial" accessors when defined as a predicate method

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -68,6 +68,10 @@ Style/PercentLiteralDelimiters:
     "%w": []
     "%W": []
 
+# Allow "trivial" accessors when defined as a predicate? method
+Style/TrivialAccessors:
+  AllowPredicates: true
+
 ################################################################################
 # Rails - disable things because we're primarily non-rails
 ################################################################################


### PR DESCRIPTION
Should predicate methods which wrap an instance variable expected to be a
falsey or truthy value be allowed by our style guide?

``` ruby
def predicate?
  @predicate
end
```
