### PR TITLE
rm invalid Style/Blocks rule

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -101,7 +101,3 @@ Style/ClassAndModuleChildren:
 Style/BlockDelimiters:
   Exclude:
   - spec/**/*
-
-Style/Blocks:
-  Exclude:
-  - spec/**/*


### PR DESCRIPTION
Rubocop emits a warning about this being an invalid cop, and I don't see it anywhere in Rubocop's full defaults: https://github.com/bbatsov/rubocop/blob/master/config/default.yml
