### PR TITLE
Disable rubocop's Style/Next check

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -72,6 +72,9 @@ Style/PercentLiteralDelimiters:
 Style/TrivialAccessors:
   AllowPredicates: true
 
+Style/Next:
+  Enabled: false
+
 ################################################################################
 # Rails - disable things because we're primarily non-rails
 ################################################################################


### PR DESCRIPTION
This check require you to use `next` instead of also allowing `if`
blocks within loops, which is not necessarily always the cleanest way to
format the conditional. Visually, the indented `if` block is easier to
see than `next unless ...`

@codeclimate/review
