### PR TITLE
Rubcop: configure TrailingComma* rules

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -29,6 +29,9 @@ Style/StringLiterals:
 Style/TrailingComma:
   EnforcedStyleForMultiline: comma
 
+Style/TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: comma
+
 # We avoid GuardClause because it can result in "suprise return"
 Style/GuardClause:
   Enabled: false


### PR DESCRIPTION
A recent version split these out from the `TrailingComma` rule, I
think.

@codeclimate/review