### PR TITLE
Disable redundant merge check

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -81,6 +81,13 @@ Style/Next:
 # We think it's OK to use the "extend self" module pattern
 Style/ModuleFunction:
   Enabled: false
+  
+################################################################################
+# Performance
+################################################################################
+
+Performance/RedundantMerge:
+  Enabled: false
 
 ################################################################################
 # Rails - disable things because we're primarily non-rails


### PR DESCRIPTION
This seems to be a micro-optimization and `merge!` is generally cleaner here.