### PR TITLE
Disallow extra spacing for token alignment

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -81,7 +81,11 @@ Style/Next:
 # We think it's OK to use the "extend self" module pattern
 Style/ModuleFunction:
   Enabled: false
-  
+
+# Disallow extra spacing for token alignment
+Style/ExtraSpacing:
+  AllowForAlignment: false
+
 ################################################################################
 # Performance
 ################################################################################


### PR DESCRIPTION
This rule should remove the need for "don't align tokens" comments in PRs. I've run into this coming from an organization that preferred token alignment.

```ruby
# bad
something = 1
another   = 2

# good
something = 1
another = 2
```