### PR TITLE
Enforce double quotes for strings all the time.

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -25,6 +25,9 @@ Style/Documentation:
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes
+
 # Use a trailing comma to keep diffs clean when elements are inserted or removed
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma


### PR DESCRIPTION
This rule seems like a strange exception to our normal "always double
quotes" practice. It also leads to (to me) visually confusing code when
methods dealing with strings appear in #{} blocks. I suggest we make
this also require double quotes so everything is consistent.

cc @codeclimate/review