### PR TITLE
Prefer `return false` over `preventDefault`

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,33 @@ set shiftwidth=2
 - No blank lines after opening or before closing a block
 - No blank lines after starting or before closing a class or module definition
 
+## JavaScript
+
+### ESLint
+
+This repo contains an `eslintrc.js` file that should be included (as
+`.eslintrc.js`) in each project. Periodically, a repo's `.eslintrc.js` file
+should be synced with the one here.
+
+### JQuery
+
+- Prefer `return false` over `event.preventDefault()` when you don't need the
+  event to bubble up.
+
+  ```javascript
+  // Bad
+  $(".js-item").click(function(event) {
+    event.preventDefault();
+    $(this).hide();
+  });
+
+  // Good
+  $(".js-item").click(function() {
+    $(this).hide();
+    return false;
+  });
+  ```
+
 ## Haskell
 
 ### Safety


### PR DESCRIPTION
Returning false implies both `preventDefault` and `stopPropagation`,
which is usually the intended effect of a handler. More info:
http://stackoverflow.com/a/1357151

@codeclimate/review 