### PR TITLE
JS: enforce camel case

### DIFF
--- a/javascript/eslintrc.js
+++ b/javascript/eslintrc.js
@@ -3,10 +3,11 @@ module.exports = {
     "node": true,     // When in a backend context
     "browser": true,  // When in a web context
     "jquery": true,   // When in a web context
-    "es6": true,
+    "es6": true,      // When using ES6 features
   },
   "rules": {
     "brace-style": [2, "1tbs", { "allowSingleLine": true }],
+    "camelcase": [2, { "properties": "always" }],
     "comma-style": [2, "first", { exceptions: {ArrayExpression: true, ObjectExpression: true} }],
     "complexity": [2, 6],
     "curly": 2,


### PR DESCRIPTION
We seem to be bad at sticking to this rule, so I think it's worth
enforcing it.

I think part of why we haven't done this before is that we were afraid
of triggering this on code interacting with JSON fields from API
responses, which generally *are* underscored. From my local testing,
I actually don't think that's a concern: the rule seems to trigger on
assignment/creation (`var foo_bar`, `{ name_blah: true}`, etc.), but not
access (e.g. `thing.foo_bar()` and `thing["attr_name"]` don't trigger
this).

Thoughts, @codeclimate/review?