### PR TITLE
Update `Style/PercentLiteralDelimiters` cop configuration

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -71,8 +71,10 @@ Style/PredicateName:
 # We use %w[ ], not %w( ) because the former looks like an array
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:
-    "%w": []
-    "%W": []
+    "%i": "[]"
+    "%I": "[]"
+    "%w": "[]"
+    "%W": "[]"
 
 # Allow "trivial" accessors when defined as a predicate? method
 Style/TrivialAccessors:


### PR DESCRIPTION
The current version of RuboCop expects these configuration values to be
strings, not arrays:

```console
no implicit conversion of Array into String
/usr/lib/ruby/gems/2.2.0/gems/rubocop-0.37.2/lib/rubocop/cop/style/percent_literal_delimiters.rb:73:in `include?'
/usr/lib/ruby/gems/2.2.0/gems/rubocop-0.37.2/lib/rubocop/cop/style/percent_literal_delimiters.rb:73:in `block (2 levels) in contains_preferred_delimiter?'
/usr/lib/ruby/gems/2.2.0/gems/rubocop-0.37.2/lib/rubocop/cop/style/percent_literal_delimiters.rb:73:in `any?'
/usr/lib/ruby/gems/2.2.0/gems/rubocop-0.37.2/lib/rubocop/cop/style/percent_literal_delimiters.rb:73:in `block in contains_preferred_delimiter?'
/usr/lib/ruby/gems/2.2.0/gems/rubocop-0.37.2/lib/rubocop/cop/style/percent_literal_delimiters.rb:73:in `any?'
/usr/lib/ruby/gems/2.2.0/gems/rubocop-0.37.2/lib/rubocop/cop/style/percent_literal_delimiters.rb:73:in `contains_preferred_delimiter?'
/usr/lib/ruby/gems/2.2.0/gems/rubocop-0.37.2/lib/rubocop/cop/style/percent_literal_delimiters.rb:56:in `on_percent_literal'
/usr/lib/ruby/gems/2.2.0/gems/rubocop-0.37.2/lib/rubocop/cop/mixin/percent_literal.rb:15:in `process'
/usr/lib/ruby/gems/2.2.0/gems/rubocop-0.37.2/lib/rubocop/cop/style/percent_literal_delimiters.rb:12:in `on_array'
/usr/lib/ruby/gems/2.2.0/gems/rubocop-0.37.2/lib/rubocop/cop/commissioner.rb:42:in `block (2 levels) in on_array'
/usr/lib/ruby/gems/2.2.0/gems/rubocop-0.37.2/lib/rubocop/cop/commissioner.rb:97:in `with_cop_error_handling'
/usr/lib/ruby/gems/2.2.0/gems/rubocop-0.37.2/lib/rubocop/cop/commissioner.rb:41:in `block in on_array'
/usr/lib/ruby/gems/2.2.0/gems/rubocop-0.37.2/lib/rubocop/cop/commissioner.rb:40:in `each'
/usr/lib/ruby/gems/2.2.0/gems/rubocop-0.37.2/lib/rubocop/cop/commissioner.rb:40:in `on_array'
/usr/lib/ruby/gems/2.2.0/gems/rubocop-0.37.2/lib/rubocop/ast_node/traversal.rb:78:in `on_casgn'
/usr/lib/ruby/gems/2.2.0/gems/rubocop-0.37.2/lib/rubocop/cop/commissioner.rb:46:in `on_casgn'
```