### PR TITLE
Enable no-unused-vars eslint rule

### DIFF
--- a/javascript/eslintrc.js
+++ b/javascript/eslintrc.js
@@ -14,6 +14,7 @@ module.exports = {
     "eqeqeq": [2, "allow-null"],
     "no-shadow-restricted-names": 2,
     "no-undef": 2,
+    "no-unused-vars": 2,
     "no-use-before-define": 2,
     "quotes": [2, "double", "avoid-escape"],
     "radix": 2,


### PR DESCRIPTION
Without this rule enabled, it's too easy to accidentally leave in
variables that you used to use but no longer need, which can make your
code kind of confusing.