### PR TITLE
Make no-unused-vars config be more RuboCop-like

### DIFF
--- a/javascript/eslintrc.js
+++ b/javascript/eslintrc.js
@@ -14,7 +14,7 @@ module.exports = {
     "eqeqeq": [2, "allow-null"],
     "no-shadow-restricted-names": 2,
     "no-undef": 2,
-    "no-unused-vars": 2,
+    "no-unused-vars": [2, { "argsIgnorePattern": "^_" }],
     "no-use-before-define": 2,
     "quotes": [2, "double", "avoid-escape"],
     "radix": 2,


### PR DESCRIPTION
This allows functions like this:

```js
function(_event) {
  console.log("I am not using the _event variable");
}
```