### PR TITLE
Update config to match ruby alignment preferences

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -100,6 +100,20 @@ Style/ExtraSpacing:
 Style/AndOr:
   EnforcedStyle: conditionals
 
+Style/AlignParameters:
+  EnforcedStyle: with_fixed_indentation
+
+Style/MultilineOperationIndentation:
+  EnforcedStyle: indented
+
+Style/AlignHash:
+  EnforcedLastArgumentHashStyle: ignore_implicit
+
+# This has the behavior we want, but it has a bug in it which produces a lot of false positives
+# https://github.com/bbatsov/rubocop/issues/3462
+# MultilineMethodCallBraceLayout:
+#   EnforcedStyle: new_line
+
 ################################################################################
 # Performance
 ################################################################################


### PR DESCRIPTION
This came out of applying our styleguide to a repo and not loving all of
the changes that it suggested
(https://github.com/codeclimate/codeclimate-services/pull/111).

cc @codeclimate/review 