### PR TITLE
Fully qualify classnames in specs

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -201,7 +201,7 @@ DSL methods, it's probably fine.
 
 - Avoid `described_class`
 - Avoid `let`, and `subject` (prefer factory methods)
-- Place `describe` within the namespace(s) for inner classes
+- [Fully qualify classname](https://gist.github.com/toddmohney/1c88cbcc5568f919afe21f03c7603057) in top-level `describe` statement
 - Prefer `expect` syntax when possible
 - Prefer spies to mocks when possible (mocks put assertion before action)
 - Test only one thing per example in unit specs


### PR DESCRIPTION
Fully qualified classnames do not suffer from [auto-loading issues](https://gist.github.com/toddmohney/1c88cbcc5568f919afe21f03c7603057)