### PR TITLE
Allow described_class in specs

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -199,7 +199,6 @@ A developer should be able to view any `it` block in isolation --without its
 **exactly** what's going on. If you can accomplish this while using the RSpec
 DSL methods, it's probably fine.
 
-- Avoid `described_class`
 - Avoid `let`, and `subject` (prefer factory methods)
 - Place `describe` within the namespace(s) for inner classes
 - Prefer `expect` syntax when possible


### PR DESCRIPTION
`described_class` makes it easier to change the name/namespace of the class. (think 'make it easy to do the right thing' where the 'right thing' here is refactoring to a better name)

Lowering the barrier to this type of change will make it easier for us to correct domain debt.