### PR TITLE
Add `no-ternary` to ESLint config

### DIFF
--- a/javascript/eslintrc.js
+++ b/javascript/eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
     "curly": 2,
     "eqeqeq": [2, "allow-null"],
     "no-shadow-restricted-names": 2,
+    "no-ternary": 2,
     "no-undef": 2,
     "no-unused-vars": [2, { "argsIgnorePattern": "^_" }],
     "no-use-before-define": 2,


### PR DESCRIPTION
Avoiding ternary's is part of our Ruby styleguide, and I think it's something we
generally want to be consistent about cross-language. ESLint has a rule for it,
so this will help enforce this.

cc @codeclimate/review