### PR TITLE
Enable rails cops

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -5,7 +5,9 @@
 Every project should start with the `rubocop.yml` present here. It should
 enforce the styles defined here.
 
-It should be pulled in via [external configuration]:
+It should be pulled in via [external configuration].
+
+### Non-Rails ruby code bases
 
 ```
 prepare:
@@ -28,6 +30,31 @@ inherit_from: base_rubocop.yml
 
 If a change or addition comes up in the course of that project that is not
 project-specific, it should be made in the styleguide.
+
+### Rails code bases
+
+If the project is a Rails app, it should pull in the Rails config file as well:
+
+```
+prepare:
+  fetch:
+  - url: "https://raw.githubusercontent.com/codeclimate/styleguide/master/ruby/rubocop.yml"
+    path: "base_rubocop.yml"
+  - url: "https://raw.githubusercontent.com/codeclimate/styleguide/master/ruby/rails_rubocop.yml"
+    path: "rails_rubocop.yml"
+
+engines:
+  rubocop:
+    enabled: true
+```
+
+And the project should have a `.rubocop.yml` that looks like:
+
+```
+inherit_from: rails_rubocop.yml
+
+# project-specific configuration...
+```
 
 ## General
 

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -1,13 +1,33 @@
 # Ruby
 
-## Rubocop
+## RuboCop
 
 Every project should start with the `rubocop.yml` present here. It should
 enforce the styles defined here.
 
+It should be pulled in via [external configuration]:
+
+```
+prepare:
+  fetch:
+  - url: "https://raw.githubusercontent.com/codeclimate/styleguide/master/ruby/rubocop.yml"
+    path: "base_rubocop.yml"
+
+engines:
+  rubocop:
+    enabled: true
+```
+
+And the project should have a `.rubocop.yml` that looks like:
+
+```
+inherit_from: base_rubocop.yml
+
+# project-specific configuration...
+```
+
 If a change or addition comes up in the course of that project that is not
-project-specific, it should be made in both places. Periodically, projects must
-"sync" their `.rubocop.yml` with the one present here.
+project-specific, it should be made in the styleguide.
 
 ## General
 
@@ -233,3 +253,5 @@ set shiftwidth=2
 ```
 "rulers": [ 80 ]
 ```
+
+[external configuration]: https://docs.codeclimate.com/v1.0/docs/configuring-the-prepare-step

--- a/ruby/rails_rubocop.yml
+++ b/ruby/rails_rubocop.yml
@@ -1,0 +1,4 @@
+inherit_from: base_rubocop.yml
+
+Rails:
+  Enabled: true

--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -122,13 +122,10 @@ Performance/RedundantMerge:
   Enabled: false
 
 ################################################################################
-# Rails - disable things because we're primarily non-rails
+# Rails - disabled because we're primarily non-Rails
 ################################################################################
 
-Rails/Delegate:
-  Enabled: false
-
-Rails/TimeZone:
+Rails:
   Enabled: false
 
 ################################################################################


### PR DESCRIPTION
I noticed that in our Rails app, we explicitly enable some Rails cops,
but without this bit, those cops aren't actually enabled.

This change also enables a number of _other_ Rails cops, some of which I
suppose we aren't necessarily enthusiastic about.

The one I specifically was eager to enable was Rails/ActionFilter... I'd
like to open a PR against our Rails apps to use this new flow and see
what issues they sniff out and then revisit disabling some cops at that
point.
