### PR TITLE
Disable ActiveRecord-specific cops

### DIFF
--- a/ruby/rails_rubocop.yml
+++ b/ruby/rails_rubocop.yml
@@ -2,3 +2,9 @@ inherit_from: base_rubocop.yml
 
 Rails:
   Enabled: true
+
+# Disabling ActiveRecord-related cops
+Rails/DynamicFindBy:
+  Enabled: false
+Rails/FindBy:
+  Enabled: false


### PR DESCRIPTION
We don't use ActiveRecord, so these find false positives in our code
bases.