### PR TITLE
Turn off rubocop's FormatStringToken check

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -31,12 +31,16 @@ Metrics/PerceivedComplexity:
 
 ################################################################################
 # Style
-################################################################################
+###############################################################################
 
 # Executables are conventionally named bin/foo-bar
 Style/FileName:
   Exclude:
   - bin/**/*
+
+# Naming format tokens is often less readable, especially with time values.
+Style/FormatStringToken:
+  Enabled: false
 
 # We don't (currently) document our code
 Style/Documentation:


### PR DESCRIPTION
This appeared when we recently upgraded RuboCop: I don't think it's a
style we should enforce.

The named tokens in format strings can be useful in very complicated
cases, but those cases are not the norm, and the check's suggested style
makes simple cases *less* readable.

In 0.52.0 it also has bugs leading to many false positives where
changing the code as suggested would result in incorrect behavior:
https://github.com/bbatsov/rubocop/issues/5245. E.g. it wants me to rewrite `time.strftime("%b %d, %l:%M %p")` as something like `time.strftime("%<month>b %<day>d, %<hour>l:%<month>M %<ampm>p")`, which does not work at all.