### PR TITLE
Use "indented" style for MultilineMethodCallIndentation

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -142,6 +142,9 @@ Style/AlignHash:
 # MultilineMethodCallBraceLayout:
 #   EnforcedStyle: new_line
 
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
 # We prefer alias_method. This cop's documentation actually indicates that's
 # what it enforces, but it seems to behave exactly the opposite.
 Style/Alias:


### PR DESCRIPTION
The current (default) value for this check wants chained assignments to
look like:

```
foo =
  Foo.
  bar.
  baz
```

That is not a style I think anybody on our team habitually writes. What
I think we tend to do (and which matches the `indented` style) is:

```
foo = Foo.
  bar.
  baz
```

Since AFAIK this is already the most common de-facto style we use, we
should probably set that in the styleguide.