### PR TITLE
BlockDelimiters cop uses semantic style.

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -33,6 +33,11 @@ Metrics/PerceivedComplexity:
 # Style
 ###############################################################################
 
+Style/BlockDelimiters:
+  EnforcedStyle: semantic
+  Exclude:
+  - spec/**/*
+
 # Executables are conventionally named bin/foo-bar
 Style/FileName:
   Exclude:
@@ -176,9 +181,5 @@ Rails:
 ################################################################################
 
 Style/ClassAndModuleChildren:
-  Exclude:
-  - spec/**/*
-
-Style/BlockDelimiters:
   Exclude:
   - spec/**/*


### PR DESCRIPTION
The default option for Style/BlockDelimiters, `line_count_based`, simply
counts the number of lines in the block to determine whether to use
braces or do/end. These leads to superficial visual consistency, but
actually contradicts the semantic rule, which says that the choice of
braces vs do/end should depend on whether the block's purpose is
functional or procedural, i.e. whether it returns a value or has side
effects. When possible we should be using static analysis to enforce
conventions around a programmer's intent, which is more critical
information than how many lines a piece of code has.

The `semantic` option, used here, is implemented with a relatively
simple check to see if the return value of the block is assigned,
receives a method call, or is the last thing inside of an outer scope
that will thus return it. General consensus on the PR is that, although you
can probably find some edge-cases that will lead to counterintuitive
rule interpretations, this is a good-enough implementation.

Implementing PR: https://github.com/rubocop-hq/rubocop/pull/1731
Jim Weirich's initial request for the feature (RIP):
  https://github.com/rubocop-hq/ruby-style-guide/issues/162