### PR TITLE
Replace some trivial Rubocop checks with more meaningful Reek checks.

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -56,6 +56,41 @@ inherit_from: rails_rubocop.yml
 # project-specific configuration...
 ```
 
+## Reek
+
+Every project should start with the `reek.yml` present here. It should
+enforce the styles defined here.
+
+It should be pulled in via [external configuration].
+
+```
+prepare:
+  fetch:
+  - url: "https://raw.githubusercontent.com/codeclimate/styleguide/master/ruby/reek.yml"
+    path: ".reek.yml"
+
+engines:
+  reek:
+    enabled: true
+```
+
+Reek does not support config inheritance, so you will not add a
+project-specific file.
+
+Reek has strong opinions about object-orientation that many find
+overaggressive in some parts of codebases where OO design is less
+important. You may find these common exclusions to be helpful:
+
+```
+engines:
+  reek:
+    enabled: true
+  exclude_paths:
+    - spec/
+    - app/helpers
+    - app/controllers
+```
+
 ## General
 
 - Align `private`, `protected`, etc with other definitions (do not out-dent)

--- a/ruby/rails_rubocop.yml
+++ b/ruby/rails_rubocop.yml
@@ -8,3 +8,6 @@ Rails/DynamicFindBy:
   Enabled: false
 Rails/FindBy:
   Enabled: false
+
+Rails/Present:
+  Enabled: false

--- a/ruby/reek.yml
+++ b/ruby/reek.yml
@@ -1,0 +1,34 @@
+---
+detectors:
+  Attribute:
+    enabled: false
+  BooleanParameter:
+    enabled: false
+  ControlParameter:
+    enabled: false
+  DuplicateMethodCall:
+    enabled: false
+  InstanceVariableAssumption:
+    enabled: false
+  IrresponsibleModule:
+    enabled: false
+  NestedIterators:
+    enabled: false
+  MissingSafeMethod:
+    enabled: false
+  NilCheck:
+    enabled: false
+  TooManyConstants:
+    enabled: false
+  TooManyInstanceVariables:
+    enabled: false
+  TooManyMethods:
+    enabled: false
+  TooManyStatements:
+    enabled: false
+  UncommunicativeModuleName:
+    enabled: false
+  UncommunicativeVariableName:
+    enabled: false
+  UtilityFunction:
+    enabled: false

--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -1,4 +1,17 @@
 ################################################################################
+# Layout
+################################################################################
+
+Layout/AlignParameters:
+  Enabled: false
+
+Layout/EmptyLinesAroundClassBody:
+  Enabled: false
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
+################################################################################
 # Metrics
 ################################################################################
 
@@ -51,9 +64,8 @@ Style/FormatStringToken:
 Style/Documentation:
   Enabled: false
 
-# Always use double-quotes to keep things simple
 Style/StringLiterals:
-  EnforcedStyle: double_quotes
+  Enabled: false
 
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
@@ -67,6 +79,12 @@ Style/TrailingCommaInArrayLiteral:
 
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
+
+Style/TrailingWhitespace:
+  Enabled: false
+
+Style/YodaConditions:
+  Enabled: false
 
 # We avoid GuardClause because it can result in "suprise return"
 Style/GuardClause:
@@ -120,9 +138,8 @@ Style/Next:
 Style/ModuleFunction:
   Enabled: false
 
-# Disallow extra spacing for token alignment
 Style/ExtraSpacing:
-  AllowForAlignment: false
+  Enabled: false
 
 # and/or in conditionals has no meaningful difference (only gotchas), so we
 # disallow them there. When used for control flow, the difference in precedence
@@ -133,8 +150,8 @@ Style/ExtraSpacing:
 Style/AndOr:
   EnforcedStyle: conditionals
 
-Style/AlignParameters:
-  EnforcedStyle: with_fixed_indentation
+Style/MultilineBlockChain:
+  Enabled: false
 
 Style/MultilineOperationIndentation:
   EnforcedStyle: indented
@@ -146,9 +163,6 @@ Style/AlignHash:
 # https://github.com/bbatsov/rubocop/issues/3462
 # MultilineMethodCallBraceLayout:
 #   EnforcedStyle: new_line
-
-Layout/MultilineMethodCallIndentation:
-  EnforcedStyle: indented
 
 # We prefer alias_method. This cop's documentation actually indicates that's
 # what it enforces, but it seems to behave exactly the opposite.


### PR DESCRIPTION
Our Ruby static analysis makes extensive use of Rubocop, but in my opinion Reek is a superior analysis tool for Ruby: It offers sophisticated checks that point the way towards better object-oriented design, as opposed to the more superficial analysis style of Rubocop.

This PR is a suggested way to adopt Reek: By taking on some of its checks, and at the same time removing some Rubocop checks that are relatively low value. The goal here is to keep roughly the same amount of static analysis strictness, but refocusing developer effort on deeper analysis of OO design.

As a proof of concept I've run these changes on velocity here: https://codeclimate.com/repos/59f12f7da7c8dc02c00011be/pull/12377