### PR TITLE
Turn off reek LongParameterList

### DIFF
--- a/ruby/reek.yml
+++ b/ruby/reek.yml
@@ -14,6 +14,8 @@ detectors:
     enabled: false
   IrresponsibleModule:
     enabled: false
+  LongParameterList:
+    enabled: false
   NestedIterators:
     enabled: false
   MissingSafeMethod:


### PR DESCRIPTION
This is redundant with a built-in CC Quality check: https://docs.codeclimate.com/docs/maintainability